### PR TITLE
Fix/catch zeroinertia cornercase

### DIFF
--- a/include/urdf2robcogen/Utils.hpp
+++ b/include/urdf2robcogen/Utils.hpp
@@ -13,8 +13,8 @@
 #include <urdf2robcogen/UrdfStructure.hpp>
 
 Eigen::Matrix3d inertiaMatrixFromLink(const urdf::Link& link);
-bool isValidInertiaMatrix(Eigen::Matrix3d I);
-Eigen::Matrix3d expressInertiaFromFrameAInComFrame(Eigen::Matrix3d A_I_A, double m, PoseInWorld poseA, PoseInWorld poseC);
+bool isValidInertiaMatrix(const Eigen::Matrix3d& I);
+Eigen::Matrix3d expressInertiaFromFrameAInComFrame(const Eigen::Matrix3d& A_I_A, double m, const PoseInWorld& poseA, const PoseInWorld& poseC);
 
 Eigen::Matrix3d skewSymMatrixFromVector(const Eigen::Vector3d& vec);
 

--- a/src/Urdf2RobCoGen.cpp
+++ b/src/Urdf2RobCoGen.cpp
@@ -172,18 +172,20 @@ void moveInertiaFromTo(LinkInfo& linkInfoA, LinkInfo& linkInfoB) {
   double massB = linkInfoB.inertia_->m_;
   double massTot = massA + massB;
 
-  // New center of mass position
-  PoseInWorld newComPose;
-  newComPose.position_ = massA / massTot * comPoseInWorldA.position_ + massB / massTot * comPoseInWorldB.position_;
-  newComPose.rotationWorldToFrame_ = comPoseInWorldB.rotationWorldToFrame_;
+  if (massTot > 0.0) {
+    // New center of mass position
+    PoseInWorld newComPose;
+    newComPose.position_ = massA / massTot * comPoseInWorldA.position_ + massB / massTot * comPoseInWorldB.position_;
+    newComPose.rotationWorldToFrame_ = comPoseInWorldB.rotationWorldToFrame_;
 
-  Eigen::Matrix3d I_ofA_inNewCom = expressInertiaFromFrameAInComFrame(linkInfoA.inertia_->I_, massA, comPoseInWorldA, newComPose);
-  Eigen::Matrix3d I_ofB_inNewCom = expressInertiaFromFrameAInComFrame(linkInfoB.inertia_->I_, massB, comPoseInWorldB, newComPose);
+    Eigen::Matrix3d I_ofA_inNewCom = expressInertiaFromFrameAInComFrame(linkInfoA.inertia_->I_, massA, comPoseInWorldA, newComPose);
+    Eigen::Matrix3d I_ofB_inNewCom = expressInertiaFromFrameAInComFrame(linkInfoB.inertia_->I_, massB, comPoseInWorldB, newComPose);
 
-  // All inertia is assigned to B with the new com location
-  linkInfoB.inertia_->comFramePoseInWorld_ = newComPose;
-  linkInfoB.inertia_->m_ = massTot;
-  linkInfoB.inertia_->I_ = I_ofA_inNewCom + I_ofB_inNewCom;
+    // All inertia is assigned to B with the new com location
+    linkInfoB.inertia_->comFramePoseInWorld_ = newComPose;
+    linkInfoB.inertia_->m_ = massTot;
+    linkInfoB.inertia_->I_ = I_ofA_inNewCom + I_ofB_inNewCom;
+  } // if both masses are zero, there is no inertia to move and we leave B as it is.
 
   // A will no longer have inertia
   linkInfoA.inertia_.reset();

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,7 +28,7 @@ bool isValidInertiaMatrix(Eigen::Matrix3d inertia) {
   bool isValid = true;
 
   Eigen::VectorXcd eigenvalues = inertia.eigenvalues();
-  isValid &= (eigenvalues.real().minCoeff() >= 0.0);
+  isValid &= (eigenvalues.real().minCoeff() > -1e-9);
   isValid &= (eigenvalues.imag().cwiseAbs().maxCoeff() < 1e-9);
 
   isValid &= (std::fabs(inertia(0, 1) - inertia(1, 0)) < 1e-6);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -24,12 +24,15 @@ Eigen::Matrix3d inertiaMatrixFromLink(const urdf::Link& link) {
   return inertia;
 }
 
-bool isValidInertiaMatrix(Eigen::Matrix3d inertia) {
+bool isValidInertiaMatrix(const Eigen::Matrix3d& inertia) {
+  // Eigenvalues might be come slightly negative when the inertia matrix has a eigenvalue that is numerically close to zero.
+  const double eigenValueTolerance = 1e-9;
+
   bool isValid = true;
 
   Eigen::VectorXcd eigenvalues = inertia.eigenvalues();
-  isValid &= (eigenvalues.real().minCoeff() > -1e-9);
-  isValid &= (eigenvalues.imag().cwiseAbs().maxCoeff() < 1e-9);
+  isValid &= (eigenvalues.real().minCoeff() > -eigenValueTolerance);
+  isValid &= (eigenvalues.imag().cwiseAbs().maxCoeff() < eigenValueTolerance);
 
   isValid &= (std::fabs(inertia(0, 1) - inertia(1, 0)) < 1e-6);
   isValid &= (std::fabs(inertia(0, 2) - inertia(2, 0)) < 1e-6);
@@ -38,17 +41,18 @@ bool isValidInertiaMatrix(Eigen::Matrix3d inertia) {
   return isValid;
 }
 
-Eigen::Matrix3d expressInertiaFromFrameAInComFrame(Eigen::Matrix3d A_I_A, double m, PoseInWorld poseA, PoseInWorld poseCom) {
+Eigen::Matrix3d expressInertiaFromFrameAInComFrame(const Eigen::Matrix3d& A_I_A, double m, const PoseInWorld& poseA,
+                                                   const PoseInWorld& poseCom) {
   // Notation A_I_C = inertia w.r.t point C expressed in frame A
   // Relative orientation
   const Eigen::Quaterniond& q_A_W = poseA.rotationWorldToFrame_;
   const Eigen::Quaterniond& q_C_W = poseCom.rotationWorldToFrame_;
-  const Eigen::Quaterniond& q_A_C = q_A_W * q_C_W.inverse();  // rotates a vector from frame C to A
-  const Eigen::Matrix3d R_A_C = q_A_C.toRotationMatrix();     // rotates a vector from frame C to A
+  const Eigen::Quaterniond q_A_C = q_A_W * q_C_W.inverse();  // rotates a vector from frame C to A
+  const Eigen::Matrix3d R_A_C = q_A_C.toRotationMatrix();    // rotates a vector from frame C to A
 
   // Relative position
-  const Eigen::Vector3d& W_r_A_C = poseA.position_ - poseCom.position_;  // vector from C to A in world frame
-  const Eigen::Vector3d C_r_A_C = q_C_W * W_r_A_C;                       // vector from C to A in C frame
+  const Eigen::Vector3d W_r_A_C = poseA.position_ - poseCom.position_;  // vector from C to A in world frame
+  const Eigen::Vector3d C_r_A_C = q_C_W * W_r_A_C;                      // vector from C to A in C frame
 
   // Rotate inertia into frame C
   const Eigen::Matrix3d C_I_A = R_A_C.transpose() * A_I_A * R_A_C;


### PR DESCRIPTION
We were dividing by zero if a mass-less link was a child of a mass-less link. The things people come up with..

Eigen value zero check needs to be relaxed for numerical reasons.